### PR TITLE
Enhances EDGE-V usability

### DIFF
--- a/tools/edge_v/README.md
+++ b/tools/edge_v/README.md
@@ -18,7 +18,7 @@ Edge-V works with the following operating sysetms and software stacks.
 *  Autotools build software for Linux
 *  Unified Community Velocity Model C-language (UCVMC) library: http://scec.usc.edu/scecpedia/UCVMC/ 
 *  Proj.4 projection library: http://trac.osgeo.org/proj/ (provided in UCVMC)
-*  Mesh-Oriented dAtABase (MOAB) library: http://sigma.mcs.anl.gov/moab-library/ (contained in submodules of EDGE)
+*  Mesh-Oriented datABase (MOAB) library: http://sigma.mcs.anl.gov/moab-library/ (contained in submodules of EDGE)
 
 
 ## Build Instructions

--- a/tools/edge_v/README.md
+++ b/tools/edge_v/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-BSD3-blue.svg)](LICENSE.md) 
 
 
-EDGE Velocity (EDGE-V) is a tool used to annotate the meshes with velocity model data. It is developed based on [Unified Community Velocity Model](http://scec.usc.edu/scecpedia/UCVMC)(UCVM), which is the data source, and [Mesh-Oriented dAtABase](http://sigma.mcs.anl.gov/moab-library)(MOAB).
+EDGE Velocity (EDGE-V) is a tool used to annotate the meshes with velocity model data. It is developed based on [Unified Community Velocity Model](http://scec.usc.edu/scecpedia/UCVMC)(UCVM), which is the data source, and [Mesh-Oriented datABase](http://sigma.mcs.anl.gov/moab-library)(MOAB).
 
 EDGE-V is released as an open-source scientific software under the BSD3 software license.
 

--- a/tools/edge_v/src/vm_constants.h
+++ b/tools/edge_v/src/vm_constants.h
@@ -1,0 +1,46 @@
+/**
+ * @file This file is part of EDGE.
+ *
+ * @author Rajdeep Konwar (rkonwar AT ucsd.edu)
+ *
+ * @section LICENSE
+ * Copyright (c) 2017, Regents of the University of California
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @section DESCRIPTION
+ * This file contains definition of compile time constants for Edge-V.
+ **/
+
+#ifndef VM_CONSTANTS_H
+#define VM_CONSTANTS_H
+
+#define EDGE_V_OUT (std::cout << "EDGE-V INFO: ")
+#define EDGE_V_ERR (std::cerr << "EDGE-V ERR : ")
+
+#define ELMTTYPE 4  //TODO
+
+#define UCVMCMODE UCVM_COORD_GEO_ELEV
+#define UCVMTYPE  2 //TODO
+
+#define MIN_VP          1500.0
+#define MIN_VS          500.0
+#define MIN_VS2         1200.0
+#define MAX_VP_VS_RATIO 3.0
+
+#define CENTERICLON -117.916
+#define CENTERICLAT 33.933
+
+typedef int     int_v;
+typedef double  real;
+
+#endif //! VM_CONSTANTS_H

--- a/tools/edge_v/src/vm_utility.cpp
+++ b/tools/edge_v/src/vm_utility.cpp
@@ -2,6 +2,7 @@
  * @file This file is part of EDGE.
  *
  * @author Junyi Qiu (juq005 AT ucsd.edu)
+ * @author Rajdeep Konwar (rkonwar AT ucsd.edu)
  *
  * @section LICENSE
  * Copyright (c) 2017, Regents of the University of California
@@ -21,345 +22,340 @@
  * This file contains the utility routines of Edge-V.
  **/
 
-#include <iostream>
 #include <fstream>
-#include <sstream>
-#include <stdio.h>
-#include <assert.h>
 #include <omp.h>
 
 #include "vm_utility.h"
 
-extern "C" {
-#include "ucvm.h"
-}
-#include "proj_api.h"
-#include "moab/Core.hpp"
-
-using namespace moab;
-using namespace std;
-
-#define UCVMCMODE UCVM_COORD_GEO_ELEV
-
-#define MIN_VP 1500.0
-#define MIN_VS 500.0
-#define MIN_VS2 1200.0
-#define MAX_VP_VS_RATIO 3.0
-
-#define CENTERICLON -117.916
-#define CENTERICLAT 33.933
-
-#define ELMTTYPE 4 //TODO
-
-#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
-#define max(X, Y) (((X) < (Y)) ? (X) : (Y))
-
-
-
-int antnInit(antn_cfg & a_cfg, const string &cfg_f) {
+int antnInit( antn_cfg & a_cfg, const std::string &cfg_f ) {
   a_cfg.antn_cfg_fn = cfg_f;
 
-  a_cfg.min_vp = 0;
-  a_cfg.min_vs = 0;
-  a_cfg.min_vs2 = 0;
+  a_cfg.min_vp          = 0;
+  a_cfg.min_vs          = 0;
+  a_cfg.min_vs2         = 0;
   a_cfg.max_vp_vs_ratio = 0;
 
   a_cfg.hypoc.lon = 0;
   a_cfg.hypoc.lat = 0;
 
-  cout << "Reading Annotation Config File: " << cfg_f << " ... ";
-  cout.flush();
+  std::cout << "Reading Annotation Config File: " << cfg_f << " ... ";
+  std::cout.flush();
 
-  ifstream iMshFs(cfg_f.c_str(), ios::in);
-  if (iMshFs == NULL) {
-    cout << "Failed." << endl;
-    cerr << "Error: cannot open the annotation config file." << endl;
-    exit(-1);
+  std::ifstream iMshFs( cfg_f.c_str(), std::ios::in );
+  if( !iMshFs.is_open() ) {
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: cannot open the config file." << std::endl;
+    exit( -1 );
   }
 
-  string lineBuf;
-  while (getline(iMshFs, lineBuf)) {
+  std::string lineBuf;
+  while( getline( iMshFs, lineBuf ) ) {
     int i = -1, j;
-    while ((++i < lineBuf.length()) && (lineBuf[i] == ' ')) ;
-    if ((i >= lineBuf.length()) || (lineBuf[i] == '#')) continue;
 
-    j = i-1;
-    while ((++j < lineBuf.length()) && (lineBuf[j] != '=')) ;
-    if (j >= lineBuf.length()) continue;
+    while( (++i < lineBuf.length()) && (lineBuf[i] == ' ') );
 
-    string varName = lineBuf.substr(i, j-i);
-    string varValue = lineBuf.substr(j+1);
-    if (varName.compare("ucvm_config") == 0) a_cfg.ucvm_cfg_fn = varValue;
-    else if (varName.compare("ucvm_model_list") == 0) a_cfg.ucvm_model_list = varValue;
-    else if (varName.compare("mesh_file") == 0) a_cfg.mesh_fn = varValue;
-    else if (varName.compare("node_vm_file") == 0) a_cfg.vm_node_fn = varValue;
-    else if (varName.compare("elmt_vm_file") == 0) a_cfg.vm_elmt_fn = varValue;
-    else if (varName.compare("h5m_file") == 0) a_cfg.h5m_fn = varValue;
-    else 
-      cout << "\nUnknown setting (" << varName << "). Ignored." << endl;
+    if( (i >= lineBuf.length()) || (lineBuf[i] == '#') )
+      continue;
+
+    j = i - 1;
+
+    while( (++j < lineBuf.length()) && (lineBuf[j] != '=') );
+
+    if( j >= lineBuf.length() )
+      continue;
+
+    std::string varName   = lineBuf.substr( i, j - i );
+    std::string varValue  = lineBuf.substr( j + 1 );
+
+    if( varName.compare( "ucvm_config" ) == 0 )
+      a_cfg.ucvm_cfg_fn     = varValue;
+    else if( varName.compare( "ucvm_model_list" ) == 0 )
+      a_cfg.ucvm_model_list = varValue;
+    else if( varName.compare( "mesh_file" ) == 0 )
+      a_cfg.mesh_fn         = varValue;
+    else if( varName.compare( "node_vm_file" ) == 0 )
+      a_cfg.vm_node_fn      = varValue;
+    else if( varName.compare( "elmt_vm_file" ) == 0 )
+      a_cfg.vm_elmt_fn      = varValue;
+    else if( varName.compare( "h5m_file" ) == 0 )
+      a_cfg.h5m_fn          = varValue;
+    else
+      std::cout << "\nUnknown setting (" << varName << "). Ignored." << std::endl;
   }
 
-
-  a_cfg.ucvm_cmode=UCVMCMODE;
-  a_cfg.ucvm_type = 2; //TODO
+  a_cfg.ucvm_cmode  = UCVMCMODE;
+  a_cfg.ucvm_type   = UCVMTYPE;
 
   a_cfg.min_vp = (a_cfg.min_vp == 0) ? MIN_VP : a_cfg.min_vp;
   a_cfg.min_vs = (a_cfg.min_vs == 0) ? MIN_VS : a_cfg.min_vs;
   a_cfg.min_vs2 = (a_cfg.min_vs2 == 0) ? MIN_VS2 : a_cfg.min_vs2;
-  a_cfg.max_vp_vs_ratio = (a_cfg.max_vp_vs_ratio == 0) ? MAX_VP_VS_RATIO : a_cfg.max_vp_vs_ratio;
+  a_cfg.max_vp_vs_ratio = (a_cfg.max_vp_vs_ratio == 0) ? \
+                          MAX_VP_VS_RATIO : a_cfg.max_vp_vs_ratio;
 
   a_cfg.hypoc.lon = CENTERICLON;
   a_cfg.hypoc.lat = CENTERICLAT;
 
   a_cfg.elmt_type = ELMTTYPE;
 
-
-  cout << "Done!" << endl;
-
-  return 0;
-}
-
-int ucvmInit(const antn_cfg &a_cfg) {
-  ucvm_init(a_cfg.ucvm_cfg_fn.c_str());
-  ucvm_add_model_list(a_cfg.ucvm_model_list.c_str());
-  ucvm_setparam(UCVM_PARAM_QUERY_MODE, a_cfg.ucvm_cmode);
+  std::cout << "Done!" << std::endl;
 
   return 0;
 }
 
-int meshInit(moab_mesh &m_mesh, antn_cfg &a_cfg){
-  if (m_mesh.intf != NULL) {
-    cout << "Failed." << endl;
-    cerr << "Error: The mesh has been initialized." << endl;
-    exit(-1);
+int ucvmInit( const antn_cfg &a_cfg ) {
+  ucvm_init( a_cfg.ucvm_cfg_fn.c_str() );
+  ucvm_add_model_list( a_cfg.ucvm_model_list.c_str() );
+  ucvm_setparam( UCVM_PARAM_QUERY_MODE, a_cfg.ucvm_cmode );
+
+  return 0;
+}
+
+int meshInit( moab_mesh &m_mesh, antn_cfg &a_cfg ) {
+  if( m_mesh.intf != nullptr ) {
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: The mesh has been initialized." << std::endl;
+    exit( -1 );
   }
 
-  m_mesh.intf = new Core;
-  Interface *iface = m_mesh.intf;
+  m_mesh.intf = new moab::Core;
+  moab::Interface *iface = m_mesh.intf;
 
-  cout << "Reading Mesh File: " << a_cfg.mesh_fn << " ... " << endl;
+  std::cout << "Reading Mesh File: " << a_cfg.mesh_fn << " ... " << std::endl;
 
-  // Load the mesh from msh file
-  ErrorCode rval = iface->load_mesh( a_cfg.mesh_fn.c_str() );
-  if (rval != MB_SUCCESS) {
-    cout << "Failed." << endl;
-    cerr << "Error: cannot open the mesh file." << endl;
-    exit(-1);
+  //! Load the mesh from msh file
+  moab::ErrorCode rval = iface->load_mesh( a_cfg.mesh_fn.c_str() );
+  if( rval != moab::MB_SUCCESS ) {
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: cannot open the mesh file." << std::endl;
+    exit( -1 );
   }
-  assert(rval == MB_SUCCESS);
+  assert( rval == moab::MB_SUCCESS );
 
-  // Get Nodes && Tets Statistics
+  //! Get Nodes && Tets Statistics
   int numNodes, numElmts;
-  Range verts, elems;
-  rval = iface->get_number_entities_by_type(0, MBVERTEX, numNodes);
-  assert(rval == MB_SUCCESS);
-  rval = iface->get_number_entities_by_type(0, MBTET, numElmts);
-  assert(rval == MB_SUCCESS);
-  rval = iface->get_entities_by_type(0, MBVERTEX, verts);
-  assert(rval == MB_SUCCESS);
-  assert(verts.size() == numNodes);
-  rval = iface->get_entities_by_type(0, MBTET, elems);
-  assert(rval == MB_SUCCESS);
-  assert(elems.size() == numElmts);
+  moab::Range verts, elems;
+
+  rval = iface->get_number_entities_by_type( 0, moab::MBVERTEX, numNodes );
+  assert( rval == moab::MB_SUCCESS );
+
+  rval = iface->get_number_entities_by_type( 0, moab::MBTET, numElmts );
+  assert( rval == moab::MB_SUCCESS );
+
+  rval = iface->get_entities_by_type( 0, moab::MBVERTEX, verts );
+  assert( rval == moab::MB_SUCCESS );
+  assert( verts.size() == numNodes );
+
+  rval = iface->get_entities_by_type( 0, moab::MBTET, elems );
+  assert( rval == moab::MB_SUCCESS );
+  assert( elems.size() == numElmts );
 
   m_mesh.num_nodes = numNodes;
   m_mesh.num_elmts = numElmts;
-  cout << " | Number of vertices is " << m_mesh.num_nodes << endl;
-  cout << " | Number of elements is " << m_mesh.num_elmts << endl;
+  std::cout << " | Number of vertices is " << m_mesh.num_nodes << std::endl;
+  std::cout << " | Number of elements is " << m_mesh.num_elmts << std::endl;
 
-  cout << "Done!" << endl;
-  
+  std::cout << "Done!" << std::endl;
+
   return 0;
 }
 
-int meshFinalize(moab_mesh &m_mesh){
-  if (m_mesh.intf != NULL) {
+int meshFinalize( moab_mesh &m_mesh ) {
+  if( m_mesh.intf != nullptr ) {
     delete m_mesh.intf;
   } else {
-    cout << "Failed." << endl;
-    cerr << "Error: mesh object corrupted.";
-    exit(-1);
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: mesh object corrupted.";
+    exit( -1 );
   }
-  
+
   return 0;
 }
 
-int vmNodeInit(vmodel &vm_nodes, const moab_mesh &m_mesh) {
+int vmNodeInit( vmodel &vm_nodes, const moab_mesh &m_mesh ) {
   vm_nodes.vm_list = new vm_datum[m_mesh.num_nodes];
 
   return 0;
 }
 
-int vmNodeFinalize(vmodel &vm_nodes) {
-  if (vm_nodes.vm_list != NULL)
+int vmNodeFinalize( vmodel &vm_nodes ) {
+  if( vm_nodes.vm_list != nullptr )
     delete[] vm_nodes.vm_list;
 
   return 0;
 }
 
-int vmElmtInit(vmodel &vm_elmts, const moab_mesh &m_mesh) {
+int vmElmtInit( vmodel &vm_elmts, const moab_mesh &m_mesh ) {
   vm_elmts.vm_list = new vm_datum[m_mesh.num_elmts];
 
   return 0;
 }
 
-int vmElmtFinalize(vmodel &vm_elmts) {
-  if (vm_elmts.vm_list != NULL)
+int vmElmtFinalize( vmodel &vm_elmts ) {
+  if( vm_elmts.vm_list != nullptr )
     delete[] vm_elmts.vm_list;
 
   return 0;
 }
 
-int workerInit(worker_reg &wrk_rg, unsigned int totalNum) {
-  unsigned int tid = omp_get_thread_num();
-  unsigned int numThrds = omp_get_num_threads();
+int workerInit( worker_reg &wrk_rg, int_v totalNum ) {
+  int_v tid         = omp_get_thread_num();
+  int_v numThrds    = omp_get_num_threads();
   wrk_rg.worker_tid = tid;
 
-  unsigned int workSize = (totalNum + numThrds - 1) / numThrds;
-  unsigned int nPrivate = min(workSize*(tid+1), totalNum) - workSize*tid;
-  wrk_rg.work_size = workSize;
-  wrk_rg.num_prvt = nPrivate;
+  int_v workSize    = (totalNum + numThrds - 1) / numThrds;
+  int_v nPrivate    = std::min( workSize * (tid + 1), totalNum ) - workSize * tid;
+  wrk_rg.work_size  = workSize;
+  wrk_rg.num_prvt   = nPrivate;
 
-  string pjInitParams = "+proj=tmerc +units=m +axis=enu +no_defs +datum=WGS84 +k=0.9996 +lon_0=-117.916 +lat_0=33.933";
-  wrk_rg.pj_utm = pj_init_plus(pjInitParams.c_str());
-  wrk_rg.pj_geo = pj_init_plus("+proj=latlong +datum=WGS84");
+  std::string pjInitParams = "+proj=tmerc +units=m +axis=enu +no_defs \
+                          +datum=WGS84 +k=0.9996 +lon_0=-117.916 +lat_0=33.933";
+  wrk_rg.pj_utm = pj_init_plus( pjInitParams.c_str() );
+  wrk_rg.pj_geo = pj_init_plus( "+proj=latlong +datum=WGS84" );
 
   return 0;
 }
 
-int writeVMNodes(vmodel &vm_nodes, const antn_cfg &a_cfg, const moab_mesh &m_mesh) {
-  cout << "Write Velocity Model: " << a_cfg.vm_node_fn << " ... ";
-  cout.flush();
+int writeVMNodes( vmodel &vm_nodes, const antn_cfg &a_cfg,
+                  const moab_mesh &m_mesh ) {
+  std::cout << "Write Velocity Model: " << a_cfg.vm_node_fn << " ... ";
+  std::cout.flush();
 
-  ofstream oVmNodeFs(a_cfg.vm_node_fn.c_str(), ios::out);
-  if (oVmNodeFs == NULL) {
-    cout << "Failed" << endl;
-    cerr << "Error: cannot generate the velocity model for nodes." << endl;
-    exit(-1);
+  std::ofstream oVmNodeFs( a_cfg.vm_node_fn.c_str(), std::ios::out );
+  if( !oVmNodeFs.is_open() ) {
+    std::cout << "Failed" << std::endl;
+    std::cerr << "Error: cannot generate the velocity model for nodes."
+              << std::endl;
+    exit( -1 );
   }
   
-  // Write down the headers
+  //! Write down the headers
   oVmNodeFs << "$UcvmModel\n";
-  oVmNodeFs << a_cfg.ucvm_model_list << endl;
+  oVmNodeFs << a_cfg.ucvm_model_list << std::endl;
   oVmNodeFs << "$EndUcvmModel\n";
 
-  // Write down the velocity model data
-  unsigned int numNodes = m_mesh.num_nodes;
+  //! Write down the velocity model data
+  int_v numNodes = m_mesh.num_nodes;
 
   oVmNodeFs << "$NodesVelocityModel\n";
-  oVmNodeFs << numNodes << endl;
-  for (int pid = 0; pid < numNodes; pid++) {
-    double data0 = vm_nodes.vm_list[pid].data[0];
-    double data1 = vm_nodes.vm_list[pid].data[1];
-    double data2 = vm_nodes.vm_list[pid].data[2];
+  oVmNodeFs << numNodes << std::endl;
+  for( int_v pid = 0; pid < numNodes; pid++ ) {
+    real data0 = vm_nodes.vm_list[pid].data[0];
+    real data1 = vm_nodes.vm_list[pid].data[1];
+    real data2 = vm_nodes.vm_list[pid].data[2];
 
-    oVmNodeFs << (pid+1) << " " << data0 << " " << data1 << " " << data2 << endl;
+    oVmNodeFs << (pid + 1) << " " << data0 << " " << data1 << " " << data2
+              << std::endl;
     oVmNodeFs.flush();
-  } 
+  }
   oVmNodeFs << "$NodesVelocityModel\n";
 
   oVmNodeFs.close();
-  cout << "Done!" << endl;
+  std::cout << "Done!" << std::endl;
 
   return 0;
 }
 
-int writeVMElmts(vmodel &vm_elmts, const antn_cfg &a_cfg, const moab_mesh &m_mesh) {
-  cout << "Writing Velocity Model: " << a_cfg.vm_elmt_fn << " ... ";
-  cout.flush();
+int writeVMElmts( vmodel &vm_elmts, const antn_cfg &a_cfg,
+                  const moab_mesh &m_mesh ) {
+  std::cout << "Writing Velocity Model: " << a_cfg.vm_elmt_fn << " ... ";
+  std::cout.flush();
 
-  ofstream oVmElmtFs(a_cfg.vm_elmt_fn.c_str(), ios::out);
-  if (oVmElmtFs == NULL) {
-    cout << "Failed" << endl;
-    cerr << "Error: cannot generate the velocity model for elements." << endl;
-    exit(-1);
+  std::ofstream oVmElmtFs( a_cfg.vm_elmt_fn.c_str(), std::ios::out );
+  if( !oVmElmtFs.is_open() ) {
+    std::cout << "Failed" << std::endl;
+    std::cerr << "Error: cannot generate the velocity model for elements."
+              << std::endl;
+    exit( -1 );
   }
-  
-  // Write down the headers
+
+  //! Write down the headers
   oVmElmtFs << "$UcvmModel\n";
-  oVmElmtFs << a_cfg.ucvm_model_list << endl;
+  oVmElmtFs << a_cfg.ucvm_model_list << std::endl;
   oVmElmtFs << "$EndUcvmModel\n";
 
-  // Write down the velocity model data
-  unsigned int numElmts = m_mesh.num_elmts;
+  //! Write down the velocity model data
+  int_v numElmts = m_mesh.num_elmts;
 
   oVmElmtFs << "$ElementsVelocityModel\n";
-  oVmElmtFs << numElmts << endl;
-  for (int eid = 0; eid < numElmts; eid++) {
-    double data0 = vm_elmts.vm_list[eid].data[0];
-    double data1 = vm_elmts.vm_list[eid].data[1];
-    double data2 = vm_elmts.vm_list[eid].data[2];
+  oVmElmtFs << numElmts << std::endl;
+  for( int_v eid = 0; eid < numElmts; eid++ ) {
+    real data0 = vm_elmts.vm_list[eid].data[0];
+    real data1 = vm_elmts.vm_list[eid].data[1];
+    real data2 = vm_elmts.vm_list[eid].data[2];
 
-    oVmElmtFs << (eid+1) << " " << data0 << " " << data1 << " " << data2 << endl;
+    oVmElmtFs << (eid + 1) << " " << data0 << " " << data1 << " " << data2
+              << std::endl;
     oVmElmtFs.flush();
-  } 
+  }
   oVmElmtFs << "$ElementsVelocityModel\n";
 
   oVmElmtFs.close();
-  cout << "Done!" << endl;
+  std::cout << "Done!" << std::endl;
 
   return 0;
 }
 
-int writeVMTags(vmodel &vm_elmts, const antn_cfg &a_cfg, const moab_mesh &m_mesh) {
-  Interface *iface = m_mesh.intf;
-  if (iface == NULL) {
-    cout << "Failed." << endl;
-    cerr << "Error: cannot operate the mesh." << endl;
-    exit(-1);
+int writeVMTags( vmodel &vm_elmts, const antn_cfg &a_cfg,
+                 const moab_mesh &m_mesh ) {
+  moab::Interface *iface = m_mesh.intf;
+  if( iface == nullptr ) {
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: cannot operate the mesh." << std::endl;
+    exit( -1 );
   }
 
-  cout << "Writing Annotated Mesh File: " << a_cfg.h5m_fn << " ... ";
-  cout.flush();
+  std::cout << "Writing Annotated Mesh File: " << a_cfg.h5m_fn << " ... ";
+  std::cout.flush();
 
-  Range elems;
-  ErrorCode rval = iface->get_entities_by_type(0, MBTET, elems);
-  assert(rval == MB_SUCCESS);
+  moab::Range elems;
+  moab::ErrorCode rval = iface->get_entities_by_type( 0, moab::MBTET, elems );
+  assert( rval == moab::MB_SUCCESS );
 
-  // Create Tags
-  Tag tag_lambda, tag_mu, tag_rho;
-  rval = iface->tag_get_handle("LAMBDA", 4, MB_TYPE_OPAQUE, tag_lambda, MB_TAG_CREAT|MB_TAG_SPARSE|MB_TAG_BYTES);
-  assert(rval == MB_SUCCESS);
-  rval = iface->tag_get_handle("MU", 4, MB_TYPE_OPAQUE, tag_mu, MB_TAG_CREAT|MB_TAG_SPARSE|MB_TAG_BYTES);
-  assert(rval == MB_SUCCESS);
-  rval = iface->tag_get_handle("RHO", 4, MB_TYPE_OPAQUE, tag_rho, MB_TAG_CREAT|MB_TAG_SPARSE|MB_TAG_BYTES);
-  assert(rval == MB_SUCCESS);
+  //! Create Tags
+  moab::Tag tag_lambda, tag_mu, tag_rho;
+  rval = iface->tag_get_handle( "LAMBDA", 4, moab::MB_TYPE_OPAQUE, tag_lambda,
+                    moab::MB_TAG_CREAT|moab::MB_TAG_DENSE|moab::MB_TAG_BYTES );
+  assert( rval == moab::MB_SUCCESS );
 
-  // Set Tags
-  unsigned int numElmts = m_mesh.num_elmts;
-  for (Range::iterator rit = elems.begin(); rit != elems.end(); rit++) {
-    EntityID entId = iface->id_from_handle(*rit);
-    
-    unsigned long long eid = entId - 1;
-    assert(eid < int(numElmts));
+  rval = iface->tag_get_handle( "MU", 4, moab::MB_TYPE_OPAQUE, tag_mu,
+                    moab::MB_TAG_CREAT|moab::MB_TAG_DENSE|moab::MB_TAG_BYTES );
+  assert( rval == moab::MB_SUCCESS );
 
-    float l_lambda, l_mu, l_rho;
-    l_lambda = vm_elmts.vm_list[eid].data[0];
-    l_mu = vm_elmts.vm_list[eid].data[1];
-    l_rho = vm_elmts.vm_list[eid].data[2];
+  rval = iface->tag_get_handle( "RHO", 4, moab::MB_TYPE_OPAQUE, tag_rho,
+                    moab::MB_TAG_CREAT|moab::MB_TAG_DENSE|moab::MB_TAG_BYTES );
+  assert( rval == moab::MB_SUCCESS );
+
+  //! Set Tags
+  int_v eid;
+  int_v numElmts = m_mesh.num_elmts;
+  real l_lambda, l_mu, l_rho;
+
+  for( moab::Range::iterator rit = elems.begin(); rit != elems.end(); ++rit ) {
+    moab::EntityID entId = iface->id_from_handle( *rit );
+
+    eid = entId - 1;
+    assert( eid < numElmts );
+
+    l_lambda  = vm_elmts.vm_list[eid].data[0];
+    l_mu      = vm_elmts.vm_list[eid].data[1];
+    l_rho     = vm_elmts.vm_list[eid].data[2];
 
 
-    iface->tag_set_data(tag_lambda, &(*rit), 1, &l_lambda);
-    assert(rval == MB_SUCCESS);
-    rval = iface->tag_set_data(tag_mu, &(*rit), 1, &l_mu);
-    assert(rval == MB_SUCCESS);
-    rval = iface->tag_set_data(tag_rho, &(*rit), 1, &l_rho);
-    assert(rval == MB_SUCCESS);
+    iface->tag_set_data( tag_lambda, &(*rit), 1, &l_lambda );
+    assert( rval == moab::MB_SUCCESS );
+
+    rval = iface->tag_set_data( tag_mu, &(*rit), 1, &l_mu );
+    assert( rval == moab::MB_SUCCESS );
+
+    rval = iface->tag_set_data( tag_rho, &(*rit), 1, &l_rho );
+    assert( rval == moab::MB_SUCCESS );
   }
 
-  // Write to H5M File
-  rval = iface->write_file(a_cfg.h5m_fn.c_str(), "H5M");
-  assert(rval == MB_SUCCESS);
+  //! Write to H5M File
+  rval = iface->write_file( a_cfg.h5m_fn.c_str(), "H5M" );
+  assert( rval == moab::MB_SUCCESS );
 
-  cout << "Done!" << endl;
+  std::cout << "Done!" << std::endl;
+
+  return 0;
 }
-
-
-
-
-
-
-
-
-
-

--- a/tools/edge_v/src/vm_utility.h
+++ b/tools/edge_v/src/vm_utility.h
@@ -2,6 +2,7 @@
  * @file This file is part of EDGE.
  *
  * @author Junyi Qiu (juq005 AT ucsd.edu)
+ * @author Rajdeep Konwar (rkonwar AT ucsd.edu)
  *
  * @section LICENSE
  * Copyright (c) 2017, Regents of the University of California
@@ -21,7 +22,11 @@
  * This is the header file for the utility routines of Edge-V.
  **/
 
+#ifndef VM_UTILITY_H
+#define VM_UTILITY_H
+
 #include <iostream>
+#include <cassert>
 #include <string>
 
 extern "C" {
@@ -29,28 +34,22 @@ extern "C" {
 }
 
 #include "proj_api.h"
-
 #include "moab/Core.hpp"
-
-using namespace std;
-
-#define EDGE_V_OUT (cout << "EDGE-V INFO: ")
-#define EDGE_V_ERR (cerr << "EDGE-V ERR : ")
+#include "vm_constants.h"
 
 
-// *** Coordination System ***
+// *** Coordinate System ***
 
 typedef struct xyz_point_t {
-  double x;
-  double y;
-  double z;
+  real x;
+  real y;
+  real z;
 } xyz_point_t;
 
-
 typedef struct geo_point_t {
-  double lon;
-  double lat;
-  double dep;
+  real lon;
+  real lat;
+  real dep;
 } geo_point_t;
 
 // **************************
@@ -59,64 +58,59 @@ typedef struct geo_point_t {
 // *** Configuration File ***
 
 typedef struct antn_cfg {
-  string antn_cfg_fn;
+  std::string antn_cfg_fn;
 
-  string ucvm_cfg_fn;
-  string ucvm_model_list;
+  std::string ucvm_cfg_fn;
+  std::string ucvm_model_list;
   ucvm_ctype_t ucvm_cmode;
   int ucvm_type;
 
-  double min_vp;
-  double min_vs;
-  double min_vs2;
-  double max_vp_vs_ratio;
+  real min_vp;
+  real min_vs;
+  real min_vs2;
+  real max_vp_vs_ratio;
 
-  string mesh_fn;
+  std::string mesh_fn;
   geo_point_t hypoc;
 
   unsigned int elmt_type;
 
-  string vm_node_fn;
-  string vm_elmt_fn;
-  string h5m_fn;
+  std::string vm_node_fn;
+  std::string vm_elmt_fn;
+  std::string h5m_fn;
 
   unsigned int parallel_mode;
   unsigned int num_worker;
-
 } antn_cfg;
 
+int antnInit( antn_cfg &, const std::string & );
 
-int antnInit(antn_cfg &, const string &);
-int ucvmInit(const antn_cfg &);
+int ucvmInit( const antn_cfg & );
 
 // // ***************************
 
 
 // // *** Coordination System ***
 
-// int xyz2geo(const xyz_point_t &, geo_point_t &);
-// int geo2xyz(const geo_point_t &, xyz_point_t &);
+// int xyz2geo( const xyz_point_t &, geo_point_t & );
+// int geo2xyz( const geo_point_t &, xyz_point_t & );
 
-// // ***************************
+// ***********************
 
 
 // *** Parallel Module ***
 
-typedef struct worker_reg
-{
-  unsigned int worker_tid;
+typedef struct worker_reg {
+  int_v worker_tid;
 
   projPJ pj_utm;
   projPJ pj_geo;
 
-  unsigned int vm_type;
-  unsigned int work_size;
-  unsigned int num_prvt;
-
-
+  int_v work_size;
+  int_v num_prvt;
 } worker_reg;
 
-int workerInit(worker_reg &, unsigned int);
+int workerInit( worker_reg &, int_v );
 
 // int pjUtmInit(projPJ **);
 // int pjUtmFinalize(projPJ *);
@@ -129,9 +123,8 @@ int workerInit(worker_reg &, unsigned int);
 
 // *** Mesh Module ***
 
-typedef struct elmt_t
-{
-  unsigned int vertex[4];
+typedef struct elmt_t {
+  unsigned int vertex[ELMTTYPE];
 } elmt;
 
 // typedef struct msh_node
@@ -144,11 +137,10 @@ typedef struct elmt_t
 //   elmt_t *elmt_list;
 // } msh_elmt;
 
-typedef struct moab_mesh
-{
-  moab::Interface *intf = NULL;
-  int num_nodes;
-  int num_elmts;
+typedef struct moab_mesh {
+  moab::Interface *intf = nullptr;
+  int_v num_nodes;
+  int_v num_elmts;
 } moab_mesh;
 
 
@@ -158,31 +150,33 @@ typedef struct moab_mesh
 // int meshElmtInit(msh_elmt &, antn_cfg &);
 // int meshElmtFinalize (msh_elmt &);
 
-int meshInit(moab_mesh &, antn_cfg &);
-int meshFinalize(moab_mesh &);
+int meshInit( moab_mesh &, antn_cfg & );
+int meshFinalize( moab_mesh & );
 
 // *******************
 
 
 // *** Velocity Model Module ***
 
-typedef struct vm_datum
-{
-  double data[3];
+typedef struct vm_datum {
+  real data[3];
 } vm_datum;
 
-typedef struct vmodel
-{
+typedef struct vmodel {
   vm_datum *vm_list;
 } vmodel;
 
-int vmNodeInit(vmodel &, const moab_mesh &);
-int vmNodeFinalize(vmodel &);
-int vmElmtInit(vmodel &, const moab_mesh &);
-int vmElmtFinalize(vmodel &);
+int vmNodeInit( vmodel &, const moab_mesh & );
+int vmElmtInit( vmodel &, const moab_mesh & );
 
-int writeVMNodes(vmodel &, const antn_cfg &, const moab_mesh &);
-int writeVMElmts(vmodel &, const antn_cfg &, const moab_mesh &);
-int writeVMTags(vmodel &, const antn_cfg &, const moab_mesh &);
+int vmNodeFinalize( vmodel & );
+int vmElmtFinalize( vmodel & );
+
+int writeVMNodes( vmodel &, const antn_cfg &, const moab_mesh & );
+int writeVMElmts( vmodel &, const antn_cfg &, const moab_mesh & );
+int writeVMTags(  vmodel &, const antn_cfg &, const moab_mesh & );
+
+// *******************
 
 
+#endif //! VM_UTILITY_H


### PR DESCRIPTION
Addresses issues as discussed in PR #3 :

1. In anticipation of larger meshes, provides typedefs for all mesh-specific integral and double types, such that we can easily replace the `int`s by `long`s and `double`s by `long double`s in the future.

1. Gets rid of the `using namespace std` and `using namespace moab`.

1. Uses `std::min` instead of the preprocessor macro `#define min(X, Y) (((X) < (Y)) ? (X) : (Y))`.

1. Replaces `MB_TAG_SPARSE` with `MB_TAG_DENSE`.

1. Adds #include guard to `vm_utility.h`.

1. Moves all definitions and typedefs to a new file `vm_constants.h`.

1. Comments out `RAD_TO_DEG` transformation for depth (m) inside `edge_v.cpp` (line 83).