### PR TITLE
Added Fault Annotation to EDGE-V

### DIFF
--- a/tools/edge_v/Makefile
+++ b/tools/edge_v/Makefile
@@ -48,7 +48,7 @@ MOABLIB=$(MOABDIR)/lib
 -include $(MOABLIB)/moab.make
 MOAB_LINKS := $(shell echo $(MOAB_LIBS_LINK) | sed 's/-all-static//g')
 
-CXXFLAGS=-I. -I$(PROJ4INC) -I$(UCVMINC) -I$(MOABINC) -fopenmp 
+CXXFLAGS=-I. -I$(PROJ4INC) -I$(UCVMINC) -I$(MOABINC) -fopenmp -std=c++11
 LDFLAGS=-L$(PROJ4LIB) -lproj -Wl,-rpath,$(PROJ4LIB)                \
         -L$(UCVMLIB)  -lucvm $(UCVMCLDFLAGS) -Wl,-rpath,$(UCVMLIB) \
         $(MOAB_LINKS) -lm -ldl
@@ -59,7 +59,7 @@ OBJDIR=./build
 RELEASE=$(PREFIX)/bin
 
 _DEPS=vm_utility.h
-_OBJ =vm_utility.o edge_v.o 
+_OBJ =vm_utility.o edge_v.o
 
 DEPS=$(patsubst %,$(SRCDIR)/%,$(_DEPS))
 OBJ =$(patsubst %,$(OBJDIR)/%,$(_OBJ))
@@ -85,4 +85,3 @@ cleanobj:
 
 clean:
 	rm -f $(OBJDIR)/*.o $(OBJDIR)/edge_v $(RELEASE)/edge_v
-

--- a/tools/edge_v/src/edge_v.cpp
+++ b/tools/edge_v/src/edge_v.cpp
@@ -215,10 +215,13 @@ int main( int argc, char **argv ) {
 
   vmNodeFinalize( vModelNodes );
 
+  fault_antn( mMsh, aCfg );
+
   writeVMElmts( vModelElmts, aCfg, mMsh );
   writeVMTags(  vModelElmts, aCfg, mMsh );
 
   vmElmtFinalize( vModelElmts );
+
   meshFinalize( mMsh );
 
   return 0;

--- a/tools/edge_v/src/vm_utility.cpp
+++ b/tools/edge_v/src/vm_utility.cpp
@@ -71,6 +71,8 @@ int antnInit( antn_cfg & a_cfg, const std::string &cfg_f ) {
       a_cfg.ucvm_cfg_fn     = varValue;
     else if( varName.compare( "ucvm_model_list" ) == 0 )
       a_cfg.ucvm_model_list = varValue;
+    else if( varName.compare( "fault_input_file" ) == 0 )
+      a_cfg.fault_input_fns.push_back( varValue );
     else if( varName.compare( "mesh_file" ) == 0 )
       a_cfg.mesh_fn         = varValue;
     else if( varName.compare( "node_vm_file" ) == 0 )
@@ -227,7 +229,7 @@ int writeVMNodes( vmodel &vm_nodes, const antn_cfg &a_cfg,
               << std::endl;
     exit( -1 );
   }
-  
+
   //! Write down the headers
   oVmNodeFs << "$UcvmModel\n";
   oVmNodeFs << a_cfg.ucvm_model_list << std::endl;
@@ -355,6 +357,441 @@ int writeVMTags( vmodel &vm_elmts, const antn_cfg &a_cfg,
   rval = iface->write_file( a_cfg.h5m_fn.c_str(), "H5M" );
   assert( rval == moab::MB_SUCCESS );
 
+  std::cout << "Done!" << std::endl;
+
+  return 0;
+}
+
+
+
+//
+// Class definitions and helper methods for fault annotation
+//
+// A planar fault is assumed, with initial data given at a series of
+// grid points.  We assume that the y-axis is coplanar with the fault
+// plane, but the x and z axes need not be.
+// Based on the SCEC/USGSG TPV35 Benchmark. For more information see:
+// http://scecdata.usc.edu/cvws/download/TPV35_Description_v05.pdf
+// http://scecdata.usc.edu/cvws/tpv35docs.html
+
+
+// ************************************
+// * Begin Triangle class definitions *
+// ************************************
+Triangle::Triangle( double* i_coords ){
+  if( i_coords == nullptr ){
+    std::cerr << "Error: Attempted to dereference null ptr in Triangle ctor"
+              << std::endl;
+    exit( -1 );
+  }
+  m_v1.x = i_coords[0];
+  m_v1.y = i_coords[1];
+  m_v1.z = i_coords[2];
+  m_v2.x = i_coords[3];
+  m_v2.y = i_coords[4];
+  m_v2.z = i_coords[5];
+  m_v3.x = i_coords[6];
+  m_v3.y = i_coords[7];
+  m_v3.z = i_coords[8];
+}
+
+
+xyz_point_t Triangle::centroid(){
+  xyz_point_t l_centroid;
+  l_centroid.x = ( m_v1.x + m_v2.x + m_v3.x ) / 3;
+  l_centroid.y = ( m_v1.y + m_v2.y + m_v3.y ) / 3;
+  l_centroid.z = ( m_v1.z + m_v2.z + m_v3.z ) / 3;
+
+  return l_centroid;
+}
+
+
+xyz_point_t Triangle::bary_to_phy( xyz_point_t i_b ){
+  xyz_point_t l_phys;
+  l_phys.x = i_b.x * m_v1.x + i_b.y * m_v2.x + i_b.z * m_v3.x;
+  l_phys.y = i_b.x * m_v1.y + i_b.y * m_v2.y + i_b.z * m_v3.y;
+  l_phys.z = i_b.x * m_v1.z + i_b.y * m_v2.z + i_b.z * m_v3.z;
+
+  return l_phys;
+}
+
+
+// refine is the number of new subdivisions made to each side of triangle
+// EX: refine=0 --> No refinement;    refine=2 --> 9 subtriangles
+std::vector< Triangle > Triangle::subdivide( unsigned int i_refine ){
+  Triangle                l_subtri;
+  std::vector< Triangle > l_subtriangles;
+  xyz_point_t             l_bary1, l_bary2, l_bary3, l_bary4;
+
+  double                  h = 1.0 / (i_refine + 1);
+
+//  Reference:
+//        v3
+//        * *                         b3 * * * * * b4
+//   ^    *   *                       *  *          *
+//   |    *     *                     *    *        *
+//   |    * * * * *                   *      *      *
+//   | i  * *     * *                 *        *    *
+//   |    *   *   *   *               *          *  *
+//        *     * *     *             b1 * * * * * b2
+//        v1* * * * * * * v2
+//              j
+//          ------->
+//
+// We order the subtriangles increasing from v1 to v2
+// and then upward toward v3. Barycentric coordinates
+// are used to map from the reference element to physical
+// space.
+  for( int i = 0; i <= i_refine; i++ ){
+    for( int j = 0; j <= i_refine - i; j++ ){
+      l_bary1.x = 1 - j*h - i*h;
+      l_bary1.y = j*h;
+      l_bary1.z = i*h;
+
+      l_bary2.x = 1 - (j+1)*h - i*h;
+      l_bary2.y = (j+1)*h;
+      l_bary2.z = i*h;
+
+      l_bary3.x = 1 - j*h - (i+1)*h;
+      l_bary3.y = j*h;
+      l_bary3.z = (i+1)*h;
+
+      l_bary4.x = 1 - (j+1)*h + (i+1)*h;
+      l_bary4.y = (j+1)*h;
+      l_bary4.z = (i+1)*h;
+
+      l_subtri.m_v1 = bary_to_phy( l_bary1 );
+      l_subtri.m_v2 = bary_to_phy( l_bary2 );
+      l_subtri.m_v3 = bary_to_phy( l_bary3 );
+      l_subtriangles.push_back( l_subtri );
+
+      if( j + i < i_refine ){
+        l_subtri.m_v1 = bary_to_phy( l_bary4 );
+        l_subtri.m_v2 = bary_to_phy( l_bary3 );
+        l_subtri.m_v3 = bary_to_phy( l_bary2 );
+        l_subtriangles.push_back( l_subtri );
+      }
+    }
+  }
+  return l_subtriangles;
+}
+// ************************************
+// ** End Triangle class definitions **
+// ************************************
+
+
+// ************************************
+// ** Begin FModel class definitions **
+//*************************************
+FModel::FModel( std::vector< std::string > i_fInputFns ){
+  // Open Fault Input File
+  m_filenames = i_fInputFns;
+  std::cout << "Reading Fault Input File header from: " << m_filenames[0]
+            << " ... " << std::flush;
+
+  std::ifstream l_faultIfs( m_filenames[0], std::ios::in );
+  if( !l_faultIfs.is_open() ){
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: Cannot open the fault input file." << std::endl;
+    exit( -1 );
+  }
+
+  // Read the header
+  std::string l_lineBuf;
+  getline( l_faultIfs, l_lineBuf );
+  std::istringstream l_lineStream( l_lineBuf );
+
+  l_lineStream >> m_Nx;
+  l_lineStream >> m_Ny;
+  l_lineStream >> m_xMin;
+  l_lineStream >> m_xMax;
+  l_lineStream >> m_yMin;
+  l_lineStream >> m_yMax;
+
+  l_faultIfs.close();
+  std::cout << "Done!" << std::endl;
+
+  size_t l_modelSize = (m_Nx + 1) * (m_Ny + 1);
+  m_faultData = new FDatum[ l_modelSize ];
+
+  // Finally, compute the inverse of the width of the grid cells for future
+  // convenience, and set fault angle
+  m_faultAngle = 0 * M_PI/180.;
+  m_xScaleInv = m_Nx / (m_xMax - m_xMin);
+  m_yScaleInv = m_Ny / (m_yMax - m_yMin);
+
+  std::cout << " | Number of cells (x-axis): " << m_Nx << std::endl;
+  std::cout << " | Number of cells (y-axis): " << m_Ny << std::endl;
+  std::cout << " | Min x coordinate:         " << m_xMin << std::endl;
+  std::cout << " | Max x coordinate:         " << m_xMax << std::endl;
+  std::cout << " | Min y coordinate:         " << m_yMin << std::endl;
+  std::cout << " | Max y coordinate:         " << m_yMax << std::endl;
+  std::cout << " | Fault Angle:              " << m_faultAngle << std::endl;
+
+  std::cout << "Fault model parameter setup completed." << std::endl;
+}
+
+
+FModel::~FModel(){
+  if( m_faultData != nullptr ){
+    delete[] m_faultData;
+  }
+  else{
+    std::cerr << "Warning: Attempted to delete non-existant Fault Model Data"
+              << std::endl;
+  }
+}
+
+
+void FModel::populate(){
+  int                 l_nx, l_ny;
+  double              l_x, l_y;
+  double              l_sFric, l_sStress, l_nStress;
+  std::string         l_lineBuf;
+  std::ifstream       l_faultIfs;
+  std::istringstream  l_lineStream;
+
+  std::cout << "Populating fault model from: " << std::endl;
+  for( const auto& l_filename : m_filenames ){
+    std::cout << "    > " << l_filename << std::endl;
+
+    l_faultIfs.open( l_filename, std::ios::in );
+    if( !l_faultIfs.is_open() ){
+      std::cout << "Failed." << std::endl;
+      std::cerr << "Error: Cannot open " << l_filename << std::endl;
+      exit( -1 );
+    }
+
+    getline( l_faultIfs, l_lineBuf );   // Ignore the first line (header)
+    while( getline( l_faultIfs, l_lineBuf ) ){
+      l_lineStream.clear();
+      l_lineStream.str( l_lineBuf );
+
+      l_lineStream >> l_nx;    // integer x coord, (indexed from 0)
+      l_lineStream >> l_ny;    // integer y coord, (indexed from 0)
+      l_lineStream >> l_x;     // physical x coord
+      l_lineStream >> l_y;     // physical y coord
+
+      l_lineStream >> l_sFric;
+      l_lineStream >> l_sStress;
+
+      m_faultData[ l_nx + l_ny * (m_Nx+1) ].m_sFric.push_back( l_sFric );
+      // m_faultData[ l_nx + l_ny * (m_Nx+1) ].m_nStress.push_back( m_sStress );
+      m_faultData[ l_nx + l_ny * (m_Nx+1) ].m_nStress.push_back( 60. );
+      m_faultData[ l_nx + l_ny * (m_Nx+1) ].m_sStress.push_back( l_sStress );
+    }
+
+    l_faultIfs.close();
+  }
+  std::cout << "...Done!" << std::endl;
+}
+
+
+// Assumes fault plane is rotated about axis x=0,z=0 only
+// (i.e. no variation in y coord)
+xyz_point_t FModel::proj_to_plane( xyz_point_t i_pt ){
+  xyz_point_t l_proj;
+
+  double s = sin( m_faultAngle );
+  double c = cos( m_faultAngle );
+  l_proj.x = i_pt.x * c * c + i_pt.z * s * c;
+  l_proj.y = i_pt.y;
+  l_proj.z = i_pt.x * s * c + i_pt.z * s * s;
+
+  return l_proj;
+}
+
+
+int FModel::get_nearest_nx( xyz_point_t i_pt ){
+  int l_nxNearest = std::round( m_xScaleInv * ( i_pt.x - m_xMin ) );
+
+  if( l_nxNearest < 0 )
+    l_nxNearest = 0;
+  else if( l_nxNearest > m_Nx )
+    l_nxNearest = m_Nx;
+
+  return l_nxNearest;
+}
+
+int FModel::get_nearest_ny( xyz_point_t i_pt ){
+  int l_nyNearest = std::round( m_yScaleInv * ( i_pt.y - m_yMin ) );
+
+  if( l_nyNearest < 0 )
+    l_nyNearest = 0;
+  else if( l_nyNearest > m_Ny )
+    l_nyNearest = m_Ny;
+
+  return l_nyNearest;
+}
+
+
+FDatum FModel::get_datum_pt( xyz_point_t i_pt ){
+  int         l_nx, l_ny;
+  xyz_point_t l_planePt;
+
+  l_planePt = proj_to_plane( i_pt );
+  l_nx = get_nearest_nx( l_planePt );
+  l_ny = get_nearest_ny( l_planePt );
+
+  return m_faultData[ l_nx + l_ny * (m_Nx+1) ];
+}
+
+
+FDatum FModel::get_datum_tri( Triangle i_tri ){
+  xyz_point_t l_centroid = i_tri.centroid();
+  FDatum      l_datum = get_datum_pt( l_centroid );
+
+  return l_datum;
+}
+// ************************************
+// *** End FModel class definitions ***
+// ************************************
+
+
+moab::Range get_fault_faces( moab_mesh &i_mesh ){
+  moab::Interface *iface = i_mesh.intf;
+  moab::ErrorCode l_rval;
+
+  moab::Range               l_faultFaces;
+  moab::Range               l_mSets, l_tempRange;
+  std::vector< moab::Tag >  l_tagsMesh;
+  moab::Tag                 l_tagMat;
+  std::string               l_tagMatName;
+
+  // Get Material-Type tag...
+  l_rval = iface->tag_get_tags( l_tagsMesh );
+  assert( l_rval == moab::MB_SUCCESS );
+  l_tagMat = l_tagsMesh[0];
+
+  // ...and double check that we have the right tag
+  l_rval = iface->tag_get_name( l_tagMat, l_tagMatName );
+  assert( l_rval == moab::MB_SUCCESS );
+  assert( l_tagMatName == "MATERIAL_SET" );
+
+  // Get all entity sets
+  l_rval = iface->get_entities_by_type( 0, moab::MBENTITYSET, l_mSets );
+  assert( l_rval == moab::MB_SUCCESS );
+
+  // Read off the material type for each entity set
+  std::vector< int > l_matData;
+  l_matData.resize( l_mSets.size() );
+  iface->tag_get_data( l_tagMat, l_mSets, &l_matData[0] );
+  assert( l_rval == moab::MB_SUCCESS );
+
+  // Check if entity set has material type 201 (rupture)
+  for( size_t l_md = 0; l_md < l_matData.size(); l_md++ ){
+    if( l_matData[l_md] == 201 ){
+      l_tempRange.clear();
+      l_rval = iface->get_entities_by_handle( l_mSets[l_md], l_tempRange );
+      l_faultFaces.merge( l_tempRange );
+    }
+  }
+
+  return l_faultFaces;
+}
+
+
+// Create MOAB tag and tag each fault entity with array of doubles.
+// Each tag is an array representing the different initial
+// rupture parameters at each subtriangle and each fused run
+// See diagram:
+//
+//  x------------------------------------------------------------x
+//  |                         Fault Face                         |
+//  x-----------------------------x------------------------------x
+//  |         subtriangle1        |          subtriangle2        |
+//  x---------x---------x---------x------------------------------x
+//  | n_stress| s_stress| s_fric  |
+//  x---------x---------x---------x
+//  |cfr |cfr |
+//  x----x----x
+int fault_antn( moab_mesh &i_mesh, const antn_cfg &i_antnCfg ){
+  if( i_mesh.intf == nullptr ){
+    std::cout << "Failed." << std::endl;
+    std::cerr << "Error: Attempted to annotate an uninitialized mesh (fault data)."
+              << std::endl;
+    exit( -1 );
+  }
+
+  // Set parameters for constructing and querying fault model
+  const int l_nCfr = i_antnCfg.fault_input_fns.size();// Number of fused runs
+  const int l_refine = 0;                             // Subtri. refinement lvl
+  const int l_nSubTri = pow( l_refine+1, 2 );         // Subtris. per tet face
+
+  // Set up fault_model
+  FModel fault_model( i_antnCfg.fault_input_fns );
+  fault_model.populate();
+
+  // Get moab Range of all faces on fault
+  moab::ErrorCode         l_rval;
+  moab::Interface*        iface = i_mesh.intf;
+  moab::Range             l_faultFaces = get_fault_faces( i_mesh );
+  const int               l_numFaultFaces = l_faultFaces.size();
+  const int               l_fdSize = l_nCfr * 3;
+  const int               l_tagSize = l_nSubTri * l_fdSize;
+
+  // Declare some more data structures to be used in the mesh annotation
+  Triangle                l_tri;
+  std::vector< Triangle > l_subtriangles;
+  moab::Range             l_faceVerts;
+  double                  l_faceVertsCoords[9];
+  moab::Tag               l_tagFData;
+  FDatum                  l_fd;
+
+  double*                 l_entData = new double[ l_tagSize ];
+
+  // Get tag to hold fault parameters, creating it if it doesn't exist
+  l_rval = iface->tag_get_handle( "FAULT_DATA", l_tagSize, moab::MB_TYPE_DOUBLE,
+                                l_tagFData,
+                                moab::MB_TAG_CREAT|moab::MB_TAG_DENSE );
+  assert( l_rval == moab::MB_SUCCESS );
+
+
+  // Loop over all fault faces, annotating mesh as we go
+  int l_count = 0;
+  std::cout << "Annotating mesh with fault stresses ... " << std::endl;
+  std::cout << l_count << " of " << l_numFaultFaces << " fault entities annotated."
+            << std::flush;
+
+  for( const auto& l_faceHandle : l_faultFaces ){
+    l_faceVerts.clear();
+    l_rval = iface->get_adjacencies( &l_faceHandle, 1, 0, false, l_faceVerts );
+    assert( l_rval == moab::MB_SUCCESS );
+
+    // Ensure that vertices in triangle are ordered according to increasing id
+    // Can compare entity handles since entity type is the same for all verts
+    assert( l_faceVerts[0] < l_faceVerts[1] );
+    assert( l_faceVerts[1] < l_faceVerts[2] );
+    l_rval = iface->get_coords( l_faceVerts, l_faceVertsCoords );
+    assert( l_rval == moab::MB_SUCCESS );
+
+    // Build a triangle from the vertices of triangle entity, and subdivide
+    l_tri = Triangle( l_faceVertsCoords );
+    l_subtriangles = l_tri.subdivide( l_refine );
+    assert( l_nSubTri == l_subtriangles.size() );
+
+    // Loop over each subtriangle and get approximate fault data
+    for( int l_st = 0; l_st < l_nSubTri; l_st++ ){
+      l_fd = fault_model.get_datum_tri( l_subtriangles[ l_st ] );
+
+      for( int l_cfr = 0; l_cfr < l_nCfr; l_cfr++ ){
+        l_entData[ l_st * l_fdSize + l_cfr ]            = l_fd.m_nStress[l_cfr];
+        l_entData[ l_st * l_fdSize + l_nCfr + l_cfr ]   = l_fd.m_sStress[l_cfr];
+        l_entData[ l_st * l_fdSize + 2*l_nCfr + l_cfr ] = l_fd.m_sFric[l_cfr];
+      }
+    }
+
+    // Tag the mesh with the array of stresses
+    l_rval = iface->tag_set_data( l_tagFData, &l_faceHandle, 1, l_entData );
+    assert( l_rval == moab::MB_SUCCESS);
+
+    // Print out the progress of the mesh annotation
+    l_count++;
+    std::cout << "\r" << std::setw(70) << "\r" << std::flush;
+    std::cout << l_count << " of " << l_numFaultFaces << " completed"
+              << std::flush;
+  }
+  std::cout << std::endl;
   std::cout << "Done!" << std::endl;
 
   return 0;


### PR DESCRIPTION
Added functionality to EDGE-V for annotation of initial data onto fault surfaces in dynamic rupture scenarios.  Currently, the data structures and fault model are based off the TPV35 benchmark 
( http://scecdata.usc.edu/cvws/tpv35docs.html ).