### PR TITLE
Error norm plotting

### DIFF
--- a/tools/processing/error_norms_convergence_plots.sh
+++ b/tools/processing/error_norms_convergence_plots.sh
@@ -39,15 +39,16 @@ echo "Hi, I am starting now!"
 # $1 is /path/to/error/folder
 # $2 is NumberOfQuantities
 
-rm -r -f $1/plots
-mkdir $1/plots
+#rm -r -f $1/plots
+#mkdir $1/plots
 
-# find relevant data and extract into different files 
-# here, 
+# find relevant data and extract into different files  
 
-#: '
+
 echo 'start extracting ... '
-for timestepping in 'gts' 'lts'
+
+#for timestepping in 'gts' 'lts'
+: '
 do
 	for cl in 25 20 15 10 9 8 7 6 5 4 3 2 1
 	do
@@ -63,9 +64,10 @@ do
 		done
 	done 
 done 
+'
 
 echo 'All data extracted... start plotting'
-#'
+
 
 # plot data to pdf with gnuplot
 gnuplot -e "set terminal pdf ;
@@ -90,7 +92,11 @@ do for [l in \"1 2 inf\" ] {
 	do for [ q = 1:$2]{
 		set multiplot title 'L'.l.' Q'.q; 
 		set datafile separator comma;
+		set grid;
 		set logscale xy;
+		set size ratio 0.5;
+		set ylabel 'error';
+		set xlabel 'mesh width';
 		plot '$1/plots/l'.l.'_'.q.'_gts_pa_1.csv' with linespoints linestyle 2 title 'L'.l.' Q'.q.' gts non parallel', \
 		'$1/plots/l'.l.'_'.q.'_gts_pa_13.csv' with linespoints linestyle 4 title 'L'.l.' Q'.q.' gts parallel', \
 		'$1/plots/l'.l.'_'.q.'_lts_pa_1.csv' with linespoints linestyle 3 title 'L'.l.' Q'.q.' lts non parallel', \

--- a/tools/processing/error_norms_convergence_plots.sh
+++ b/tools/processing/error_norms_convergence_plots.sh
@@ -39,16 +39,15 @@ echo "Hi, I am starting now!"
 # $1 is /path/to/error/folder
 # $2 is NumberOfQuantities
 
-#rm -r -f $1/plots
-#mkdir $1/plots
+rm -r -f $1/plots
+mkdir $1/plots
 
 # find relevant data and extract into different files  
 
 
 echo 'start extracting ... '
 
-#for timestepping in 'gts' 'lts'
-: '
+for timestepping in 'gts' 'lts'
 do
 	for cl in 25 20 15 10 9 8 7 6 5 4 3 2 1
 	do
@@ -64,7 +63,7 @@ do
 		done
 	done 
 done 
-'
+
 
 echo 'All data extracted... start plotting'
 
@@ -75,32 +74,35 @@ set output '$1/plots/output.pdf';
 set style line 1 \
     linecolor rgb '#0060ad' \
     linetype 1 linewidth 2 \
-    pointtype 7 pointsize 1.5 ;
-set style line 2 \
+    pointtype 7 pointsize 1;
+	set style line 2 \
     linecolor rgb '#dd181f' \
     linetype 1 linewidth 2 \
-    pointtype 5 pointsize 1.5;
+    pointtype 5 pointsize 1;
 set style line 3 \
     linecolor rgb '#51ff2e' \
     linetype 1 linewidth 2 \
-    pointtype 2 pointsize 1.5;
+    pointtype 2 pointsize 1;
 set style line 4 \
     linecolor rgb '#132f38' \
     linetype 1 linewidth 2 \
-    pointtype 3 pointsize 1.5;
+    pointtype 3 pointsize 1;
 do for [l in \"1 2 inf\" ] {
 	do for [ q = 1:$2]{
 		set multiplot title 'L'.l.' Q'.q; 
 		set datafile separator comma;
 		set grid;
+		set xrange [25:1];
 		set logscale xy;
 		set size ratio 0.5;
 		set ylabel 'error';
 		set xlabel 'mesh width';
+		set xtics (1,2,5,10,20,50);
+		set format y \"%4.1e\";
 		plot '$1/plots/l'.l.'_'.q.'_gts_pa_1.csv' with linespoints linestyle 2 title 'L'.l.' Q'.q.' gts non parallel', \
 		'$1/plots/l'.l.'_'.q.'_gts_pa_13.csv' with linespoints linestyle 4 title 'L'.l.' Q'.q.' gts parallel', \
-		'$1/plots/l'.l.'_'.q.'_lts_pa_1.csv' with linespoints linestyle 3 title 'L'.l.' Q'.q.' lts non parallel', \
-		'$1/plots/l'.l.'_'.q.'_lts_pa_13.csv' with linespoints linestyle 1 title 'L'.l.' Q'.q.' lts parallel'; 
+		'$1/plots/l'.l.'_'.q.'_lts_pa_1.csv' with linespoints linestyle 1 title 'L'.l.' Q'.q.' lts non parallel', \
+		'$1/plots/l'.l.'_'.q.'_lts_pa_13.csv' with linespoints linestyle 3 title 'L'.l.' Q'.q.' lts parallel'; 
 		unset logscale;
 		unset multiplot;
 	}

--- a/tools/processing/error_norms_convergence_plots.sh
+++ b/tools/processing/error_norms_convergence_plots.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+##
+# @file This file is part of EDGE.
+#
+# @author Sarah Bachinger (sarah.bachinger AT uni-jena.de)
+#
+# @section LICENSE
+# Copyright (c) 2020, Friedrich Schiller University Jena
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# @section DESCRIPTION
+# A script to generate convergence plots from the error norms of an EDGE computation.
+# Identifies error norms in xml files and extracts them for plotting according to the error norm. 
+# The extracted files and the plots will be placed inside a "plots" folder in the same directory as the error directory.
+# MAKE SURE there is no other directory named "plots" in there!
+# The goal is to use display one plot for every error norm and quantity and display the values for gts, lts, parallel and not parallel
+#
+# Usage ./error_norms_convergence_plots.sh /path/to/error/folder NumberOfQuantities 
+# 
+# @section DEPENDENCIES
+# This file depends on the following projects: 
+# xmlstarlet: http://xmlstar.sourceforge.net/
+# gnuplot: http://www.gnuplot.info/index.html
+
+
+echo "Hi, I am starting now!"
+
+# remove and make new files
+
+rm -r -f $1/plots
+mkdir $1/plots
+
+for norm_val in '1' '2' 'inf'
+do
+	for quantity_val in $(seq 1 $2)
+	do 
+		echo "#L${norm_val} Data Quantity ${quantity_val}" > plots/l${norm_val}_${quantity_val}.csv
+	done
+done
+
+# find relevant data and extract into different files 
+# here, 
+
+for timestepping in gts lts
+do
+	for cl in 25 20 15 10 9 8 7 6 5 4 3 2 1
+	do
+		for parallel in 1 13
+		do 
+			echo $1/errors/${timestepping}_cl_${cl}_pa_${parallel}.xml
+			for i in $(seq 1 $2)
+			do
+				echo ${cl}, $(xmlstarlet sel -t -v "error_norms/l1/q[${i}]" -nl $1/errors/${timestepping}_cl_${cl}_pa_${parallel}.xml) >> $1/plots/l1_${i}.csv
+				echo ${cl}, $(xmlstarlet sel -t -v "error_norms/l2/q[${i}]" -nl $1/errors/${timestepping}_cl_${cl}_pa_${parallel}.xml) >> $1/plots/l2_${i}.csv
+				echo ${cl}, $(xmlstarlet sel -t -v "error_norms/linf/q[${i}]" -nl $1/errors/${timestepping}_cl_${cl}_pa_${parallel}.xml) >> $1/plots/linf_${i}.csv
+			done
+		done
+	done 
+done 
+
+# plot data to pdf with gnuplot
+gnuplot -e "set terminal pdf ;
+set output '$1/plots/output.pdf'; 
+set style line 1 \
+    linecolor rgb '#0060ad' \
+    linetype 1 linewidth 2 \
+    pointtype 7 pointsize 1.5 ;
+set style line 2 \
+    linecolor rgb '#dd181f' \
+    linetype 1 linewidth 2 \
+    pointtype 5 pointsize 1.5;
+set style line 3 \
+    linecolor rgb '#51ff2e' \
+    linetype 1 linewidth 2 \
+    pointtype 2 pointsize 1.5;
+set style line 4 \
+    linecolor rgb '#132f38' \
+    linetype 1 linewidth 2 \
+    pointtype 3 pointsize 1.5;
+set multiplot; 
+set yrange [0:3700];
+set datafile separator comma;
+plot [25:0] '$1/plots/l1_1.csv' with linespoints linestyle 1; 
+plot [25:0] '$1/plots/l1_2.csv' with linespoints linestyle 2; 
+plot [25:0] '$1/plots/l1_3.csv' with linespoints linestyle 3; 
+plot [25:0] '$1/plots/l1_4.csv' with linespoints linestyle 4; 
+plot [25:0] '$1/plots/l1_5.csv' with linespoints linestyle 5; 
+unset multiplot;
+set multiplot; 
+set yrange [0:45];
+set datafile separator comma;
+plot [25:0] '$1/plots/l2_1.csv' with linespoints linestyle 1; 
+plot [25:0] '$1/plots/l2_2.csv' with linespoints linestyle 2; 
+plot [25:0] '$1/plots/l2_3.csv' with linespoints linestyle 3; 
+plot [25:0] '$1/plots/l2_4.csv' with linespoints linestyle 4; 
+plot [25:0] '$1/plots/l2_5.csv' with linespoints linestyle 5; 
+unset multiplot;
+set multiplot; 
+set yrange [0:0.8];
+set datafile separator comma;
+plot [25:0] '$1/plots/linf_1.csv' with linespoints linestyle 1; 
+plot [25:0] '$1/plots/linf_2.csv' with linespoints linestyle 2; 
+plot [25:0] '$1/plots/linf_3.csv' with linespoints linestyle 3; 
+plot [25:0] '$1/plots/linf_4.csv' with linespoints linestyle 4; 
+plot [25:0] '$1/plots/linf_5.csv' with linespoints linestyle 5; 
+unset multiplot ;
+"


### PR DESCRIPTION
This PR adds a new post processing script to the EDGE repository.
It takes a directory of error values of the structure: 
![grafik](https://user-images.githubusercontent.com/87909808/134884179-8078d34a-c64e-4a03-a22c-4f5d2982da38.png)

It creates convergence plots for the different characteristic lengths. It expects data files to be of the following structure: /errors/${timestepping}_cl_${cl}_pa_${parallel}.xml, where timestepping can either be gts or lts, cl a value in between 1-10, 15, 20, 25, and parallel to be 1 or 13.
