### PR TITLE
Update to use Equation Dump / FP64 Equations / update LIBXSMM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/easylogging/easyloggingpp.git
 [submodule "submodules/libxsmm"]
 	path = submodules/libxsmm
-	url = https://github.com/breuera/libxsmm.git
+	url = https://github.com/libxsmm/libxsmm.git
 [submodule "submodules/exprtk"]
 	path = submodules/exprtk
 	url = https://github.com/3343/exprtk.git

--- a/src/impl/seismic/kernels/TimePredSingle.hpp
+++ b/src/impl/seismic/kernels/TimePredSingle.hpp
@@ -34,8 +34,6 @@
 #include "data/TernaryXsmm.hpp"
 #include "data/XsmmUtils.hpp"
 
-#define PP_T_KERNELS_XSMM_EQUATION_DUMP_TPP
-
 namespace edge {
   namespace seismic {
     namespace kernels {
@@ -103,18 +101,9 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
     //! binary kernels
     edge::data::BinaryXsmm< TL_T_REAL > b_binary;
 
-    //! ternary kernels
-    edge::data::TernaryXsmm< TL_T_REAL > t_ternary;
-
-#ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_DUMP_TPP
+    //! equation kernels
     std::vector<libxsmm_matrix_eqn_function>  e_eqns0;
-#  else
-    std::vector<libxsmm_matrix_eqn_function>  e_eqns00;
-    std::vector<libxsmm_matrix_eqn_function>  e_eqns01;
-#  endif
     std::vector<libxsmm_matrix_eqn_function>  e_eqns1;
-#endif
 
     /**
      * Generates the matrix kernels for the transposed stiffness matrices and star matrices.
@@ -189,26 +178,6 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       // zeroing: buffer for the anelastic computations
       u_unary.add(2, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_UNARY_XOR, LIBXSMM_MELTW_FLAG_UNARY_NONE);
 
-      // multiply with relaxation frequency and add
-      // addition
-      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
-      // mult + assign
-      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
-      // accumulation 2
-      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
-      b_binary.add(3, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
-
-
-      // update time integrated dofs
-      for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
-        unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
-        b_binary.add(4, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
-                      LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
-        b_binary.add(5, l_nCpMds, TL_N_QTS_E /* m, n */, TL_N_MDS, TL_N_MDS, TL_N_MDS /* ldi0, ldi1, ldo */,
-                      LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
-      }
-
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
       for( unsigned short l_de = 1; l_de < TL_O_TI; l_de++ ) {
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
 
@@ -225,15 +194,12 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         libxsmm_matrix_eqn_arg_metadata arg_metadata;
         libxsmm_matrix_eqn_op_metadata  op_metadata;
 
-#    ifdef PP_T_KERNELS_XSMM_EQUATION_DUMP_TPP
         libxsmm_bitfield unary_flags;
-#    endif
         libxsmm_bitfield binary_flags;
         libxsmm_bitfield ternary_flags;
 
         arg_singular_attr.type = LIBXSMM_MATRIX_ARG_TYPE_SINGULAR;
 
-#    ifdef PP_T_KERNELS_XSMM_EQUATION_DUMP_TPP
         // adding to eqns0 (multiply with relaxation frequency and add)
         libxsmm_blasint my_eqn0 = libxsmm_matrix_eqn_create();         /* o_derA[l_de] = l_rfs[l_rm] * (l_scratch + o_derA[l-de-1]) and o_tintA += l_scalar * o_derA (via DUMP) */
 
@@ -313,108 +279,8 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
           exit(-1);
         }
         e_eqns0.push_back(func0);
-#    else
-        // adding to eqns00 (multiply with relaxation frequency and add, part 1)
-        libxsmm_blasint my_eqn00 = libxsmm_matrix_eqn_create();         /* o_derA[l_de] = l_rfs[l_rm] * (l_scratch + o_derA[l-de-1]) */
-
-        binary_flags             = LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1;
-        op_metadata.eqn_idx      = my_eqn00;
-        op_metadata.op_arg_pos   = -1;
-        libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_BINARY_MUL, dtype_comp, binary_flags);
-
-        binary_flags             = LIBXSMM_MELTW_FLAG_BINARY_NONE;
-        op_metadata.eqn_idx      = my_eqn00;
-        op_metadata.op_arg_pos   = -1;
-        libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_BINARY_ADD, dtype_comp, binary_flags);
-
-        arg_metadata.eqn_idx     = my_eqn00;
-        arg_metadata.in_arg_pos  = 0;
-        arg_shape.m    = TL_N_MDS*TL_N_QTS_M;                           /* l_scratch, [TL_N_MDS][TL_N_QTS_M] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = TL_N_MDS*TL_N_QTS_M;
-        arg_shape.type = dtype;
-        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
-
-        arg_metadata.eqn_idx     = my_eqn00;
-        arg_metadata.in_arg_pos  = 1;
-        arg_shape.m    = TL_N_MDS*TL_N_QTS_M;                           /* o_derA[l_de-1], [TL_N_MDS][TL_N_QTS_M] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = TL_N_MDS*TL_N_QTS_M;
-        arg_shape.type = dtype;
-        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
-
-        arg_metadata.eqn_idx     = my_eqn00;
-        arg_metadata.in_arg_pos  = 2;
-        arg_shape.m    = 1;                                             /* l_rfs[l_rm], [1] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = 1;
-        arg_shape.type = dtype;
-        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
-
-        eqn_out_arg_shape.m    = TL_N_MDS*TL_N_QTS_M;                   /* o_derA[l_de], [TL_N_MDS][TL_N_QTS_M] */
-        eqn_out_arg_shape.n    = 1;
-        eqn_out_arg_shape.ld   = TL_N_MDS*TL_N_QTS_M;
-        eqn_out_arg_shape.type = dtype;
-
-        //libxsmm_matrix_eqn_tree_print( my_eqn00 );
-        //libxsmm_matrix_eqn_rpn_print ( my_eqn00 );
-        libxsmm_matrix_eqn_function func00 = libxsmm_dispatch_matrix_eqn_v2( my_eqn00, eqn_out_arg_shape );
-        if ( func00 == NULL) {
-          fprintf( stderr, "JIT for TPP equation func00 (eqn00) failed. Bailing...!\n");
-          exit(-1);
-        }
-        e_eqns00.push_back(func00);
-
-        // adding to eqns01 (multiply with relaxation frequency and add, part 2)
-
-        libxsmm_blasint my_eqn01 = libxsmm_matrix_eqn_create();         /* o_tintA += l_scalar * o_derA */
-
-        ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1;
-        op_metadata.eqn_idx      = my_eqn01;
-        op_metadata.op_arg_pos   = -1;
-        libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
-
-        arg_metadata.eqn_idx     = my_eqn01;
-        arg_metadata.in_arg_pos  = 0;
-        arg_shape.m    = TL_N_MDS*TL_N_QTS_M;                           /* o_derA, [TL_N_MDS][TL_N_QTS_M] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = TL_N_MDS*TL_N_QTS_M;
-        arg_shape.type = dtype;
-        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
-
-        arg_metadata.eqn_idx     = my_eqn01;
-        arg_metadata.in_arg_pos  = 1;
-        arg_shape.m    = 1;                                             /* l_scalar, [1] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = 1;
-        arg_shape.type = dtype;
-        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
-
-        arg_metadata.eqn_idx     = my_eqn01;
-        arg_metadata.in_arg_pos  = 2;
-        arg_shape.m    = TL_N_MDS*TL_N_QTS_M;                           /* o_tintA, [TL_N_MDS][TL_N_QTS_M] */
-        arg_shape.n    = 1;
-        arg_shape.ld   = TL_N_MDS*TL_N_QTS_M;
-        arg_shape.type = dtype;
-        libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
-
-        eqn_out_arg_shape.m    = TL_N_MDS*TL_N_QTS_M;                   /* o_tintA, [TL_N_MDS][TL_N_QTS_M] */
-        eqn_out_arg_shape.n    = 1;
-        eqn_out_arg_shape.ld   = TL_N_MDS*TL_N_QTS_M;
-        eqn_out_arg_shape.type = dtype;
-
-        //libxsmm_matrix_eqn_tree_print( my_eqn01 );
-        //libxsmm_matrix_eqn_rpn_print ( my_eqn01 );
-        libxsmm_matrix_eqn_function func01 = libxsmm_dispatch_matrix_eqn_v2( my_eqn01, eqn_out_arg_shape );
-        if ( func01 == NULL) {
-          fprintf( stderr, "JIT for TPP equation func01 (eqn01) failed. Bailing...!\n");
-          exit(-1);
-        }
-        e_eqns01.push_back(func01);
-#    endif
 
         // adding to eqns1 (update time integrated DOFs)
-
         libxsmm_blasint my_eqn1 = libxsmm_matrix_eqn_create();          /* o_tintE += l_scalar * o_derE */
 
         ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1;
@@ -461,7 +327,6 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
         }
         e_eqns1.push_back(func1);
       } /* loop over l_de for TPP equations */
-#  endif
 #endif
     }
 
@@ -554,16 +419,14 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
       }
 #endif
 
-#if defined(PP_T_KERNELS_XSMM_ELTWISE_TPP) and defined(PP_T_KERNELS_XSMM_EQUATION_TPP)
+#ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
       libxsmm_matrix_arg arg_array[5];
       libxsmm_matrix_eqn_param eqn_param;
       memset( &eqn_param, 0, sizeof(eqn_param));
       eqn_param.inputs = arg_array;
 
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_DUMP_TPP
       libxsmm_matrix_op_arg op_arg_arr[1];
       eqn_param.ops_args = op_arg_arr;
-#  endif
 #endif
 
       // iterate over time derivatives
@@ -582,12 +445,6 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         // buffer for the anelastic computations
         TL_T_REAL l_scratch[TL_N_QTS_M][TL_N_MDS];
-#if defined(PP_T_KERNELS_XSMM_ELTWISE_TPP) and !defined(PP_T_KERNELS_XSMM_EQUATION_TPP)
-        // buffer for relaxation computations
-        TL_T_REAL l_scratch2[TL_N_QTS_M][TL_N_MDS];
-        // buffer for time integrated dofs
-        TL_T_REAL l_scratch3[TL_N_QTS_E][TL_N_MDS];
-#endif
 
         if( TL_N_RMS > 0 ) {
 #ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
@@ -646,8 +503,6 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
           // multiply with relaxation frequency and add
 #ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
-#    ifdef PP_T_KERNELS_XSMM_EQUATION_DUMP_TPP
           arg_array[0].primary     = &l_scratch[0][0];
           arg_array[1].primary     = &o_derA[l_rm][l_de-1][0][0][0];
           arg_array[2].primary     = const_cast<void*>(reinterpret_cast<const void*>(&l_rfs[l_rm]));
@@ -657,32 +512,6 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
           eqn_param.output.primary = &o_tIntA[l_rm][0][0][0];
 
           e_eqns0[l_de-1](&eqn_param);
-#    else
-          arg_array[0].primary     = &l_scratch[0][0];
-          arg_array[1].primary     = &o_derA[l_rm][l_de-1][0][0][0];
-          arg_array[2].primary     = const_cast<void*>(reinterpret_cast<const void*>(&l_rfs[l_rm]));
-          eqn_param.output.primary = &o_derA[l_rm][l_de][0][0][0];
-          e_eqns00[l_de-1](&eqn_param);
-
-          arg_array[0].primary     = &o_derA[l_rm][l_de][0][0][0];
-          arg_array[1].primary     = &l_scalar;
-          arg_array[2].primary     = &o_tIntA[l_rm][0][0][0];
-          eqn_param.output.primary = &o_tIntA[l_rm][0][0][0];
-          e_eqns01[l_de-1](&eqn_param);
-#    endif
-#  else
-          /* 1. l_scratch2[][] = l_scratch[l_qt][l_md] + o_derA[l_rm][l_de-1][l_qt][l_md][0] */
-          b_binary.execute(3, 0, &l_scratch[0][0], &o_derA[l_rm][l_de-1][0][0][0], &l_scratch2[0][0]);
-
-          /* 2  o_derA[l_rm][l_de][l_qt][l_md][0] = l_rfs[l_rm] * l_scratch2[l_qt][l_md][0] */
-          b_binary.execute(3, 1, &l_scratch2[0][0], &l_rfs[l_rm], &o_derA[l_rm][l_de][0][0][0]);
-
-          /* 3.1 l_scratch2 = l_scalar * o_derA[l_rm][l_de][l_qt][l_md][0] */
-          b_binary.execute(3, 2, &o_derA[l_rm][l_de][0][0][0], &l_scalar, &l_scratch2[0][0]);
-          /* 3.2 o_tIntA[l_rm][l_qt][l_md][0] += l_scratch2[l_qt][l_md][0] */
-          b_binary.execute(3, 3, &o_tIntA[l_rm][0][0][0], &l_scratch2[0][0], &o_tIntA[l_rm][0][0][0]);
-#  endif
-
 #else
           for( unsigned short l_qt = 0; l_qt < TL_N_QTS_M; l_qt++ ) {
 #pragma omp simd
@@ -696,22 +525,11 @@ class edge::seismic::kernels::TimePredSingle: public edge::seismic::kernels::Tim
 
         // elastic: update time integrated DOFs
 #ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
         arg_array[0].primary     = &o_derE[l_de][0][0][0];                         /* [l_nCpMds, TL_N_QTS_E] */
         arg_array[1].primary     = &l_scalar;                                      /* [1] */
         arg_array[2].primary     = &o_tIntE[0][0][0];                              /* [l_nCpMds, TL_N_QTS_E] */
         eqn_param.output.primary = &o_tIntE[0][0][0];                              /* [l_nCpMds, TL_N_QTS_E] */
         e_eqns1[l_de-1](&eqn_param);
-#  else
-        /* @TODO: One could use a ternary here (but likely it is not possible right now due
-            to the missing support for TERNARY_BCAST flags outside equations) */
-
-        /* 1.1 l_scratch3 = l_scalar * o_derE[l_de][l_qt][l_md][0] */
-        b_binary.execute(4, l_de-1, &o_derE[l_de][0][0][0], &l_scalar, &l_scratch3[0][0]);
-
-        /* 1.2 o_tIntE[l_qt][l_md][0] += l_scratch3 */
-        b_binary.execute(5, l_de-1, &o_tIntE[0][0][0], &l_scratch3[0][0], &o_tIntE[0][0][0]);
-#  endif
 #else
         unsigned short l_nCpMds = (TL_N_RMS == 0) ? CE_N_ELEMENT_MODES_CK( TL_T_EL, TL_O_SP, l_de ) : TL_N_MDS;
         for( unsigned short l_qt = 0; l_qt < TL_N_QTS_E; l_qt++ ) {

--- a/src/impl/seismic/kernels/VolIntFused.hpp
+++ b/src/impl/seismic/kernels/VolIntFused.hpp
@@ -36,6 +36,12 @@
 #include "data/BinaryXsmm.hpp"
 #include "data/TernaryXsmm.hpp"
 
+/*
+FIXME:
+In the current build system, PP_T_KERNELS_XSMM_EQUATION_TPP is enabled for building all files hence a different temporary macro is used here in the PR
+*/
+#define PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED
+
 //#define USE_TERNARY
 
 #ifdef USE_TERNARY
@@ -107,6 +113,11 @@ class edge::seismic::kernels::VolIntFused: edge::seismic::kernels::VolInt< TL_T_
 
     //! ternary kernels
     edge::data::TernaryXsmm< TL_T_REAL > t_ternary;
+
+//see FIXME:#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP should be used here in the final version
+#ifdef PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED
+    libxsmm_matrix_eqn_function e_eqn;
+#endif
 
     //! pointers to the stiffness matrices
     TL_T_REAL *m_stiff[TL_N_DIS] = {};
@@ -314,6 +325,85 @@ class edge::seismic::kernels::VolIntFused: edge::seismic::kernels::VolInt< TL_T_
       b_binary.add(1, TL_N_CRS, TL_N_MDS * TL_N_QTS_M /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
 #  endif
 
+//see FIXME:#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP should be used here in the final version
+#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED
+      libxsmm_datatype dtype      = XsmmDtype<TL_T_REAL>();
+      libxsmm_datatype dtype_comp = XsmmDtype<TL_T_REAL>();
+
+      libxsmm_meqn_arg_shape  eqn_out_arg_shape;
+      libxsmm_meqn_arg_shape  arg_shape;
+
+      libxsmm_matrix_arg_attributes arg_singular_attr;
+
+      libxsmm_matrix_eqn_arg_metadata arg_metadata;
+      libxsmm_matrix_eqn_op_metadata  op_metadata;
+
+      libxsmm_bitfield binary_flags;
+      libxsmm_bitfield ternary_flags;
+
+      arg_singular_attr.type = LIBXSMM_MATRIX_ARG_TYPE_SINGULAR;
+
+      // adding to e_eqn (multiply with relaxation frequency and add)
+
+      libxsmm_blasint my_eqn = libxsmm_matrix_eqn_create();         /* io_dofsA[l_rm][][][0] += l_rfs[l_rm] * ( l_scratch[][][0] - i_tDofsA[l_rm][][][0]) */
+
+      ternary_flags            = LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1 | LIBXSMM_MELTW_FLAG_TERNARY_REUSE_IN_2_AS_OUT;
+      op_metadata.eqn_idx      = my_eqn;
+      op_metadata.op_arg_pos   = -1;
+      libxsmm_matrix_eqn_push_back_ternary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, dtype_comp, ternary_flags);
+
+      binary_flags             = LIBXSMM_MELTW_FLAG_BINARY_NONE;
+      op_metadata.eqn_idx      = my_eqn;
+      op_metadata.op_arg_pos   = -1;
+      libxsmm_matrix_eqn_push_back_binary_op_v2(op_metadata, LIBXSMM_MELTW_TYPE_BINARY_SUB, dtype_comp, binary_flags);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 0;
+      arg_shape.m    = TL_N_CRS;                                      /* l_scratch, [TL_N_CRS][TL_N_QTS_M * TL_N_MDS] */
+      arg_shape.n    = TL_N_QTS_M * TL_N_MDS;
+      arg_shape.ld   = TL_N_CRS;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 1;
+      arg_shape.m    = TL_N_CRS;                                      /* i_tDofsA[l_rm], [TL_N_CRS][TL_N_QTS_M * TL_N_MDS] */
+      arg_shape.n    = TL_N_QTS_M * TL_N_MDS;
+      arg_shape.ld   = TL_N_CRS;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 2;
+      arg_shape.m    = 1;                                             /* l_rfs[l_rm], [1] */
+      arg_shape.n    = 1;
+      arg_shape.ld   = 1;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+      arg_metadata.eqn_idx     = my_eqn;
+      arg_metadata.in_arg_pos  = 3;
+      arg_shape.m    = TL_N_CRS;                                      /* io_DofsA[l_rm], [TL_N_CRS][TL_N_QTS_M * TL_N_MDS] */
+      arg_shape.n    = TL_N_QTS_M * TL_N_MDS;
+      arg_shape.ld   = TL_N_CRS;
+      arg_shape.type = dtype;
+      libxsmm_matrix_eqn_push_back_arg_v2(arg_metadata, arg_shape, arg_singular_attr);
+
+
+      eqn_out_arg_shape.m    = TL_N_CRS;                              /* io_DofsA[l_rm], [TL_N_CRS][TL_N_QTS_M * TL_N_MDS] */
+      eqn_out_arg_shape.n    = TL_N_QTS_M * TL_N_MDS;
+      eqn_out_arg_shape.ld   = TL_N_CRS;
+      eqn_out_arg_shape.type = dtype;
+
+      //libxsmm_matrix_eqn_tree_print( my_eqn );
+      //libxsmm_matrix_eqn_rpn_print ( my_eqn );
+      e_eqn = libxsmm_dispatch_matrix_eqn_v2( my_eqn, eqn_out_arg_shape );
+      if ( e_eqn == NULL) {
+        fprintf( stderr, "JIT for TPP equation e_eqn (my_eqn) failed. Bailing...!\n");
+        exit(-1);
+      }
+#  endif
+
 #endif
     }
 
@@ -413,9 +503,18 @@ class edge::seismic::kernels::VolIntFused: edge::seismic::kernels::VolInt< TL_T_
       // buffer for the anelastic part
       TL_T_REAL l_scratch[TL_N_QTS_M][TL_N_MDS][TL_N_CRS];
 
-#ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
+//see FIXME: PP_T_KERNELS_XSMM_EQUATION_TPP should be used here in the final version instead of PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED
+#if defined(PP_T_KERNELS_XSMM_ELTWISE_TPP) && !defined(PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED)
       // buffer for relaxation computations
       TL_T_REAL l_scratch2[TL_N_QTS_M][TL_N_MDS][TL_N_CRS];
+#endif
+
+//see FIXME: PP_T_KERNELS_XSMM_EQUATION_TPP should be used here in the final version instead of PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED
+#if defined(PP_T_KERNELS_XSMM_ELTWISE_TPP) and defined(PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED)
+      libxsmm_matrix_arg arg_array[4];
+      libxsmm_matrix_eqn_param eqn_param;
+      memset( &eqn_param, 0, sizeof(eqn_param));
+      eqn_param.inputs = arg_array;
 #endif
 
       if( TL_N_RMS > 0 ) {
@@ -482,18 +581,28 @@ class edge::seismic::kernels::VolIntFused: edge::seismic::kernels::VolInt< TL_T_
 
         // multiply with relaxation frequency and add
 #ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
+//see FIXME:#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP should be used here in the final version
+#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP_VOLINTFUSED
+        arg_array[0].primary     = &l_scratch[0][0][0];
+        arg_array[1].primary     = const_cast<void*>(reinterpret_cast<const void*>(&i_tDofsA[l_rm][0][0]));
+        arg_array[2].primary     = const_cast<void*>(reinterpret_cast<const void*>(&l_rfs[l_rm]));
+        arg_array[3].primary     = &io_dofsA[l_rm][0][0][0];
+        eqn_param.output.primary = &io_dofsA[l_rm][0][0][0];
+        e_eqn(&eqn_param);
+#  else
         // @TODO: Could be replaced by a single equation (provided no data races occur)
         /* 1. l_scratch2[][][] = l_scratch[l_qt][l_md][l_cr] - i_tDofsA[l_rm][l_qt][l_md][l_cr] */
         b_binary.execute(0, 0, &l_scratch[0][0][0], &i_tDofsA[l_rm][0][0][0], &l_scratch2[0][0][0]);
 
-#  ifdef USE_TERNARY
+#    ifdef USE_TERNARY
         t_ternary.execute(0, 0, &io_dofsA[l_rm][0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
-#  else
+#    else
         /* 2.1 l_scratch2[l_qt][l_md][l_cr] *= l_rfs[l_rm] */
         b_binary.execute(1, 0, &l_scratch2[0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0]);
 
         /* 2.1 io_dofsA[l_rm][l_qt][l_md][l_cr] += l_scratch2[l_qt][l_md][l_cr] */
         b_binary.execute(1, 1, &io_dofsA[l_rm][0][0][0], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
+#    endif
 #  endif
 #else
         for( unsigned short l_qt = 0; l_qt < TL_N_QTS_M; l_qt++ ) {

--- a/src/impl/seismic/kernels/VolIntSingle.hpp
+++ b/src/impl/seismic/kernels/VolIntSingle.hpp
@@ -35,12 +35,6 @@
 #include "data/TernaryXsmm.hpp"
 #include "data/XsmmUtils.hpp"
 
-//#define USE_TERNARY
-
-#ifdef USE_TERNARY
-  #error "USE_TERNARY requires (currently missing) support for TERNARY_BCAST flags in LIBXSMM (hence switched off here)"
-#endif
-
 namespace edge {
   namespace seismic {
     namespace kernels { 
@@ -98,15 +92,8 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
     //! unary kernels
     edge::data::UnaryXsmm< TL_T_REAL > u_unary;
 
-    //! binary kernels
-    edge::data::BinaryXsmm< TL_T_REAL > b_binary;
-
-    //! ternary kernels
-    edge::data::TernaryXsmm< TL_T_REAL > t_ternary;
-
-#ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
+    //! equation kernels
     libxsmm_matrix_eqn_function e_eqn;
-#endif
 
     //! pointers to the stiffness matrices
     TL_T_REAL *m_stiff[TL_N_DIS] = {};
@@ -170,18 +157,6 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
       // zeroing the scratch
       u_unary.add(0, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_UNARY_XOR, LIBXSMM_MELTW_FLAG_UNARY_NONE);
 
-      // subtraction
-      b_binary.add(0, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_SUB, LIBXSMM_MELTW_FLAG_BINARY_NONE);
-      // accumulation
-#  ifdef USE_TERNARY
-      /* TERNARY_BCAST is only supported in equations but not in standalone TPPs */
-      t_ternary.add(0, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_TERNARY_MULADD, LIBXSMM_MELTW_FLAG_TERNARY_BCAST_SCALAR_IN_1);
-#  else
-      b_binary.add(1, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_MUL, LIBXSMM_MELTW_FLAG_BINARY_BCAST_SCALAR_IN_1);
-      b_binary.add(1, TL_N_MDS * TL_N_QTS_M, 1 /* m, n */, LIBXSMM_MELTW_TYPE_BINARY_ADD, LIBXSMM_MELTW_FLAG_BINARY_NONE);
-#  endif
-
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
       libxsmm_datatype dtype      = XsmmDtype<TL_T_REAL>();
       libxsmm_datatype dtype_comp = XsmmDtype<TL_T_REAL>();
 
@@ -257,9 +232,6 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
         fprintf( stderr, "JIT for TPP equation e_eqn (my_eqn) failed. Bailing...!\n");
         exit(-1);
       }
-#  endif
-
-
 #endif
     }
 
@@ -309,11 +281,6 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
 
       // buffer for anelastic part
       TL_T_REAL l_scratch[TL_N_QTS_M][TL_N_MDS][1];
-#if defined(PP_T_KERNELS_XSMM_ELTWISE_TPP) and !defined(PP_T_KERNELS_XSMM_EQUATION_TPP)
-      // buffer for relaxation computations
-      TL_T_REAL l_scratch2[TL_N_QTS_M][TL_N_MDS][1];
-#endif
-
 #ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
       u_unary.execute (0, 0, (TL_T_REAL*)&l_scratch[0][0][0]);
 #else
@@ -354,7 +321,7 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
         }
       }
 
-#if defined(PP_T_KERNELS_XSMM_ELTWISE_TPP) and defined(PP_T_KERNELS_XSMM_EQUATION_TPP)
+#ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
       libxsmm_matrix_arg arg_array[4];
       libxsmm_matrix_eqn_param eqn_param;
       memset( &eqn_param, 0, sizeof(eqn_param));
@@ -373,30 +340,12 @@ class edge::seismic::kernels::VolIntSingle: edge::seismic::kernels::VolInt < TL_
 
         // multiply with relaxation frequency and add
 #ifdef PP_T_KERNELS_XSMM_ELTWISE_TPP
-#  ifdef PP_T_KERNELS_XSMM_EQUATION_TPP
         arg_array[0].primary     = &l_scratch[0][0][0];
         arg_array[1].primary     = const_cast<void*>(reinterpret_cast<const void*>(&i_tDofsA[l_rm][0][0]));
         arg_array[2].primary     = const_cast<void*>(reinterpret_cast<const void*>(&l_rfs[l_rm]));
         arg_array[3].primary     = &io_dofsA[l_rm][0][0][0];
         eqn_param.output.primary = &io_dofsA[l_rm][0][0][0];
         e_eqn(&eqn_param);
-#  else
-        // @TODO: Could be replaced by a single equation (provided no data races occur)
-        /* 1. l_scratch2[][] = l_scratch[l_qt][l_md][0] - i_tDofsA[l_rm][l_qt][l_md][0] */
-        b_binary.execute(0, 0, &l_scratch[0][0][0], &i_tDofsA[l_rm][0][0][0], &l_scratch2[0][0][0]);
-
-#    ifdef USE_TERNARY
-        /* This does not work, see comments in generateKernels() */
-        /* 2. io_dofsA[l_rm][l_qt][l_md][0] += l_rfs[l_rm] * l_scratch2[l_qt][l_md][0] */
-        t_ternary.execute(0, 0, &io_dofsA[l_rm][0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
-#   else
-        /* 2.1 l_scratch2[l_qt][l_md][0] *= l_rfs[l_rm] */
-        b_binary.execute(1, 0, &l_scratch2[0][0][0], &l_rfs[l_rm], &l_scratch2[0][0][0]);
-        /* 2.1 io_dofsA[l_rm][l_qt][l_md][0] += l_scratch2[l_qt][l_md][0] */
-        b_binary.execute(1, 1, &io_dofsA[l_rm][0][0][0], &l_scratch2[0][0][0], &io_dofsA[l_rm][0][0][0]);
-#    endif
-#  endif
-
 #else
         for( unsigned short l_qt = 0; l_qt < TL_N_QTS_M; l_qt++ ) {
 #pragma omp simd

--- a/submodules/SConscript
+++ b/submodules/SConscript
@@ -72,6 +72,10 @@ if env['xsmm'] != False:
       if env['arch'] in ['hsw', 'skx', 'avx512']:
         env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_ELTWISE_TPP'] )
         env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_EQUATION_TPP'] )
+    if env['precision'] == '64':
+      if env['arch'] in ['hsw', 'skx', 'avx512']:
+        env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_ELTWISE_TPP'] )
+        env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_EQUATION_TPP'] )
   else:
     warnings.warn('  Warning: Could not enable libxsmm, continuing without.' )
     env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_VANILLA'] )

--- a/submodules/SConscript
+++ b/submodules/SConscript
@@ -71,11 +71,9 @@ if env['xsmm'] != False:
     if env['precision'] == '32':
       if env['arch'] in ['hsw', 'skx', 'avx512']:
         env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_ELTWISE_TPP'] )
-        env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_EQUATION_TPP'] )
     if env['precision'] == '64':
       if env['arch'] in ['hsw', 'skx', 'avx512']:
         env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_ELTWISE_TPP'] )
-        env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_XSMM_EQUATION_TPP'] )
   else:
     warnings.warn('  Warning: Could not enable libxsmm, continuing without.' )
     env.AppendUnique( CPPDEFINES=['PP_T_KERNELS_VANILLA'] )


### PR DESCRIPTION
Fixes Performance Regressions (only tested on x86 and enabled on x86) using eltwise TPP and outperforming Compiler, in this case GCC 11/12.

@egeor, @kvoronin-intel : Thanks for your contribution.

upstream: https://github.com/3343/edge/commit/8adf42792b16133c8b74bf6b59bcb38d2b0854f4
eltwise_tpp_old: https://github.com/3343/edge/commit/b5119a648aa3d3a9a9b130aac7827429f594568a
eltwise_tpp_new: https://github.com/alheinecke/edge/commit/c401bcbc314f2f3638e7444fa60b4eefd1ac65bd

Xeon Plat 8280 (Cascade Lake, 28 core): CFR=16
eltwise_tpp_old:
2022-07-31 09:18:33,675 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13781.9 seconds
2022-07-31 09:19:31,071 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13838.9 seconds
2022-07-31 09:18:08,589 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13756.7 seconds
2022-07-31 09:17:42,077 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13727 seconds
2022-07-31 09:18:58,363 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13803.8 seconds
Upstream:
2022-07-31 03:59:33,872 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13255.4 seconds
2022-07-31 03:58:19,903 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13181.5 seconds
2022-07-31 03:59:00,427 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13219.1 seconds
2022-07-31 03:59:18,490 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13237 seconds
2022-07-31 03:58:40,623 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 13199.3 seconds
eltwise_tpp_new (this PR):
2023-01-27 13:41:22,077 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 12658 seconds
2023-01-27 13:40:18,438 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 12591.5 seconds
2023-01-27 13:41:02,568 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 12634.4 seconds
2023-01-27 13:40:37,674 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 12636.1 seconds
2023-01-27 13:39:53,004 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 12566.7 seconds
 
Xeon Plat 8280 (Cascade Lake, 28 core): CFR=1
eltwise_tpp_old:
2022-07-31 05:51:13,241 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1491.03 seconds
2022-07-31 05:51:26,026 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1503.91 seconds
2022-07-31 05:51:12,977 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1490.8 seconds
2022-07-31 05:51:27,226 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1502.2 seconds
2022-07-31 05:51:33,023 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1507.99 seconds
Upstream:
2022-07-31 00:07:17,318 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1461.84 seconds
2022-07-31 00:07:16,697 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1458.29 seconds
2022-07-31 00:07:22,027 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1463.35 seconds
2022-07-31 00:07:27,644 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1469.15 seconds
2022-07-31 00:07:33,079 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1471.9 seconds
eltwise_tpp_new (this PR):
2023-01-27 19:58:39,668 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1448.88 seconds
2023-01-27 19:58:47,976 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1455.39 seconds
2023-01-27 19:58:42,498 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1453.08 seconds
2023-01-27 19:58:18,168 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1427.55 seconds
2023-01-27 19:58:34,141 0-0 INFO that's the duration of the computations (11360 fundamental time steps): 1441.6 seconds
